### PR TITLE
Seed comprehensive demo data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+/storage/*.sqlite
+/storage/*.db
+/storage/*.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# Free Fire Tournament Platform
+
+This repository now contains a lightweight PHP backend that implements the core
+services for a Free Fire tournament ecosystem. The API supports the Android
+player app, administrative dashboard, and staff tools described in the
+accompanying documentation.
+
+## Features
+
+- Player registration and authentication
+- Tournament catalogue with join flow and entry fee handling
+- Wallet ledger with manual deposits, withdrawals, and admin approval
+- Staff match management, including result reporting
+- Admin workflows for creating tournaments, creating matches, and reviewing
+  withdrawal requests
+
+## Project Layout
+
+```
+.
+├── bin              # CLI utilities for database setup and seeding
+├── docs             # Functional requirements, architecture, and API notes
+├── public           # HTTP entry point (use with PHP's built-in server)
+├── src              # PHP application code
+└── storage          # SQLite database location (created automatically)
+```
+
+## Getting Started
+
+1. **Install PHP 8.1+** with SQLite support.
+2. **Install dependencies** (none external) and run the migrations:
+
+   ```bash
+   php bin/migrate.php
+   php bin/seed.php   # optional, creates admin/staff/player fixtures
+   ```
+
+3. **Start the API server**:
+
+   ```bash
+   php -S localhost:8000 -t public
+   ```
+
+4. **Interact with the API** using your preferred REST client. Include the
+   `Authorization: Bearer <token>` header for protected endpoints after logging
+   in.
+
+### Default Accounts
+
+Running `php bin/seed.php` provisions sample credentials:
+
+| Role  | Email               | Password   |
+| ----- | ------------------- | ---------- |
+| Admin | admin@example.com   | admin123   |
+| Staff | staff@example.com   | staff123   |
+| User  | player@example.com  | player123  |
+
+## API Highlights
+
+The API entry point is hosted at `/api`. Core routes include:
+
+| Method | Endpoint                              | Description                         |
+| ------ | -------------------------------------- | ----------------------------------- |
+| POST   | `/api/register`                        | Create a new user account           |
+| POST   | `/api/login`                           | Authenticate and receive a token    |
+| GET    | `/api/tournaments`                     | List tournaments                    |
+| POST   | `/api/tournaments`                     | Create a tournament (admin only)    |
+| POST   | `/api/tournaments/{id}/join`           | Join a tournament                   |
+| GET    | `/api/wallet`                          | View wallet balance and ledger      |
+| POST   | `/api/wallet/deposit`                  | Deposit funds                       |
+| POST   | `/api/wallet/withdraw`                 | Request withdrawal                  |
+| GET    | `/api/admin/withdrawals`               | View withdrawal requests (admin)    |
+| POST   | `/api/admin/withdrawals/{id}/approve`  | Approve withdrawal (admin)          |
+| POST   | `/api/admin/withdrawals/{id}/reject`   | Reject withdrawal (admin)           |
+| GET    | `/api/staff/matches`                   | View matches (staff)                |
+| POST   | `/api/matches/{id}/result`             | Update match result (staff/admin)   |
+
+Review `docs/api.md` for the full endpoint catalogue and adapt the mobile/web
+clients accordingly.
+
+## Testing
+
+This starter service does not yet include automated tests. You can exercise the
+API manually or integrate your preferred testing framework (e.g. PestPHP or
+PHPUnit) as the project matures.

--- a/bin/migrate.php
+++ b/bin/migrate.php
@@ -1,0 +1,20 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/../src/autoload.php';
+
+use App\Support\Migration;
+
+if (!is_dir(__DIR__ . '/../storage')) {
+    mkdir(__DIR__ . '/../storage', 0777, true);
+}
+
+touch(__DIR__ . '/../storage/database.sqlite');
+
+try {
+    Migration::run();
+    echo "Database migrated\n";
+} catch (RuntimeException $e) {
+    fwrite(STDERR, "Migration failed: {$e->getMessage()}\n");
+    exit(1);
+}

--- a/bin/seed.php
+++ b/bin/seed.php
@@ -1,0 +1,333 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/../src/autoload.php';
+
+use App\Core\Database;
+
+try {
+    $db = Database::getConnection();
+} catch (RuntimeException $e) {
+    fwrite(STDERR, "Seeding aborted: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$tz = new \DateTimeZone('UTC');
+
+$users = [
+    [
+        'name' => 'Admin User',
+        'email' => 'admin@example.com',
+        'password' => 'admin123',
+        'role' => 'admin',
+        'created_at' => new \DateTimeImmutable('2024-05-01 08:00:00', $tz),
+    ],
+    [
+        'name' => 'Staff User',
+        'email' => 'staff@example.com',
+        'password' => 'staff123',
+        'role' => 'staff',
+        'created_at' => new \DateTimeImmutable('2024-05-01 08:30:00', $tz),
+    ],
+    [
+        'name' => 'Player One',
+        'email' => 'player@example.com',
+        'password' => 'player123',
+        'role' => 'user',
+        'created_at' => new \DateTimeImmutable('2024-05-01 09:00:00', $tz),
+    ],
+];
+
+foreach ($users as $user) {
+    $stmt = $db->prepare('SELECT id FROM users WHERE email = :email');
+    $stmt->execute(['email' => $user['email']]);
+    if ($stmt->fetch()) {
+        echo "User {$user['email']} already exists\n";
+        continue;
+    }
+
+    $insert = $db->prepare('INSERT INTO users (name, email, password_hash, role, wallet_balance, created_at) VALUES (:name, :email, :password_hash, :role, :balance, :created_at)');
+    $insert->execute([
+        'name' => $user['name'],
+        'email' => $user['email'],
+        'password_hash' => password_hash($user['password'], PASSWORD_BCRYPT),
+        'role' => $user['role'],
+        'balance' => 0,
+        'created_at' => $user['created_at']->format(DATE_ATOM),
+    ]);
+
+    echo "Created {$user['role']} {$user['email']} (password: {$user['password']})\n";
+}
+
+$userLookup = $db->prepare('SELECT id FROM users WHERE email = :email');
+$userIds = [];
+foreach ($users as $user) {
+    $userLookup->execute(['email' => $user['email']]);
+    $userIds[$user['email']] = (int) $userLookup->fetchColumn();
+}
+
+$adminId = $userIds['admin@example.com'] ?? null;
+$staffId = $userIds['staff@example.com'] ?? null;
+$playerId = $userIds['player@example.com'] ?? null;
+
+if (!$adminId || !$staffId || !$playerId) {
+    fwrite(STDERR, "Required seed users are missing; aborting related seeds.\n");
+    exit(1);
+}
+
+$tournaments = [
+    [
+        'name' => 'Free Fire Solo Showdown',
+        'description' => 'Solo bracket with three qualifying rounds and a grand final.',
+        'entry_fee' => 20.00,
+        'prize_pool' => 500.00,
+        'start_time' => '2024-05-05T15:00:00+00:00',
+        'status' => 'upcoming',
+        'created_by' => $adminId,
+        'created_at' => '2024-05-01T10:00:00+00:00',
+        'matches' => [
+            [
+                'name' => 'Qualifier Match 1',
+                'status' => 'scheduled',
+                'result_text' => null,
+                'assigned_staff_id' => $staffId,
+                'created_at' => '2024-05-02T09:00:00+00:00',
+            ],
+            [
+                'name' => 'Qualifier Match 2',
+                'status' => 'scheduled',
+                'result_text' => null,
+                'assigned_staff_id' => null,
+                'created_at' => '2024-05-02T10:00:00+00:00',
+            ],
+        ],
+        'registrations' => [
+            [
+                'user_id' => $playerId,
+                'status' => 'confirmed',
+                'created_at' => '2024-05-02T12:00:00+00:00',
+            ],
+        ],
+    ],
+    [
+        'name' => 'Free Fire Champions Cup',
+        'description' => 'Invite-only finals for the season\'s top squads.',
+        'entry_fee' => 0.00,
+        'prize_pool' => 1000.00,
+        'start_time' => '2024-04-25T18:00:00+00:00',
+        'status' => 'completed',
+        'created_by' => $adminId,
+        'created_at' => '2024-04-20T10:00:00+00:00',
+        'matches' => [
+            [
+                'name' => 'Grand Finals',
+                'status' => 'completed',
+                'result_text' => 'Squad Phoenix claimed the Bo5 series 3-1.',
+                'assigned_staff_id' => $staffId,
+                'created_at' => '2024-04-25T18:15:00+00:00',
+            ],
+        ],
+        'registrations' => [
+            [
+                'user_id' => $playerId,
+                'status' => 'confirmed',
+                'created_at' => '2024-04-21T09:00:00+00:00',
+            ],
+        ],
+    ],
+];
+
+$tournamentIds = [];
+$findTournament = $db->prepare('SELECT id FROM tournaments WHERE name = :name');
+$insertTournament = $db->prepare('INSERT INTO tournaments (name, description, entry_fee, prize_pool, start_time, status, created_by, created_at) VALUES (:name, :description, :entry_fee, :prize_pool, :start_time, :status, :created_by, :created_at)');
+
+foreach ($tournaments as $tournament) {
+    $findTournament->execute(['name' => $tournament['name']]);
+    $existingId = $findTournament->fetchColumn();
+
+    if ($existingId) {
+        echo "Tournament {$tournament['name']} already exists\n";
+        $tournamentId = (int) $existingId;
+    } else {
+        $insertTournament->execute([
+            'name' => $tournament['name'],
+            'description' => $tournament['description'],
+            'entry_fee' => $tournament['entry_fee'],
+            'prize_pool' => $tournament['prize_pool'],
+            'start_time' => $tournament['start_time'],
+            'status' => $tournament['status'],
+            'created_by' => $tournament['created_by'],
+            'created_at' => $tournament['created_at'],
+        ]);
+        $tournamentId = (int) $db->lastInsertId();
+        echo "Created tournament {$tournament['name']}\n";
+    }
+
+    $tournamentIds[$tournament['name']] = $tournamentId;
+
+    $matchFinder = $db->prepare('SELECT id FROM matches WHERE tournament_id = :tournament_id AND name = :name');
+    $matchInsert = $db->prepare('INSERT INTO matches (tournament_id, name, status, result_text, assigned_staff_id, created_at) VALUES (:tournament_id, :name, :status, :result_text, :assigned_staff_id, :created_at)');
+    foreach ($tournament['matches'] as $match) {
+        $matchFinder->execute([
+            'tournament_id' => $tournamentId,
+            'name' => $match['name'],
+        ]);
+        if ($matchFinder->fetch()) {
+            echo "Match {$match['name']} already exists for tournament {$tournament['name']}\n";
+            continue;
+        }
+
+        $matchInsert->execute([
+            'tournament_id' => $tournamentId,
+            'name' => $match['name'],
+            'status' => $match['status'],
+            'result_text' => $match['result_text'],
+            'assigned_staff_id' => $match['assigned_staff_id'],
+            'created_at' => $match['created_at'],
+        ]);
+        echo "Created match {$match['name']} for tournament {$tournament['name']}\n";
+    }
+
+    $registrationFinder = $db->prepare('SELECT id FROM registrations WHERE user_id = :user_id AND tournament_id = :tournament_id');
+    $registrationInsert = $db->prepare('INSERT INTO registrations (user_id, tournament_id, status, created_at) VALUES (:user_id, :tournament_id, :status, :created_at)');
+    foreach ($tournament['registrations'] as $registration) {
+        $registrationFinder->execute([
+            'user_id' => $registration['user_id'],
+            'tournament_id' => $tournamentId,
+        ]);
+        if ($registrationFinder->fetch()) {
+            echo "Registration already exists for user {$registration['user_id']} in tournament {$tournament['name']}\n";
+            continue;
+        }
+
+        $registrationInsert->execute([
+            'user_id' => $registration['user_id'],
+            'tournament_id' => $tournamentId,
+            'status' => $registration['status'],
+            'created_at' => $registration['created_at'],
+        ]);
+        echo "Registered user {$registration['user_id']} for tournament {$tournament['name']}\n";
+    }
+}
+
+$walletTransactions = [
+    [
+        'user_id' => $playerId,
+        'type' => 'deposit',
+        'amount' => 100.00,
+        'status' => 'completed',
+        'metadata' => ['source' => 'welcome_bonus'],
+        'created_at' => '2024-04-28T12:00:00+00:00',
+    ],
+    [
+        'user_id' => $playerId,
+        'type' => 'entry_fee',
+        'amount' => 20.00,
+        'status' => 'completed',
+        'metadata' => ['tournament_id' => $tournamentIds['Free Fire Solo Showdown'] ?? null],
+        'created_at' => '2024-05-02T12:30:00+00:00',
+    ],
+    [
+        'user_id' => $playerId,
+        'type' => 'withdrawal',
+        'amount' => 30.00,
+        'status' => 'completed',
+        'metadata' => ['reference' => 'TXN-FF-0001'],
+        'created_at' => '2024-05-03T10:00:00+00:00',
+    ],
+    [
+        'user_id' => $playerId,
+        'type' => 'withdrawal',
+        'amount' => 25.00,
+        'status' => 'pending',
+        'metadata' => new \stdClass(),
+        'created_at' => '2024-05-04T14:00:00+00:00',
+    ],
+];
+
+$transactionFinder = $db->prepare('SELECT id FROM wallet_transactions WHERE user_id = :user_id AND type = :type AND amount = :amount AND status = :status AND created_at = :created_at');
+$transactionInsert = $db->prepare('INSERT INTO wallet_transactions (user_id, type, amount, status, created_at, metadata) VALUES (:user_id, :type, :amount, :status, :created_at, :metadata)');
+
+foreach ($walletTransactions as $transaction) {
+    $transactionFinder->execute([
+        'user_id' => $transaction['user_id'],
+        'type' => $transaction['type'],
+        'amount' => $transaction['amount'],
+        'status' => $transaction['status'],
+        'created_at' => $transaction['created_at'],
+    ]);
+
+    if ($transactionFinder->fetch()) {
+        echo "Wallet transaction {$transaction['type']} ({$transaction['amount']}) already exists\n";
+        continue;
+    }
+
+    $metadata = $transaction['metadata'];
+    if (is_array($metadata) || $metadata instanceof stdClass) {
+        $metadata = json_encode($metadata);
+    }
+
+    $transactionInsert->execute([
+        'user_id' => $transaction['user_id'],
+        'type' => $transaction['type'],
+        'amount' => $transaction['amount'],
+        'status' => $transaction['status'],
+        'created_at' => $transaction['created_at'],
+        'metadata' => $metadata,
+    ]);
+    echo "Created wallet transaction {$transaction['type']} ({$transaction['amount']})\n";
+}
+
+$withdrawals = [
+    [
+        'user_id' => $playerId,
+        'amount' => 30.00,
+        'status' => 'approved',
+        'created_at' => '2024-05-03T10:05:00+00:00',
+        'reviewed_by' => $adminId,
+        'reviewed_at' => '2024-05-03T11:00:00+00:00',
+    ],
+    [
+        'user_id' => $playerId,
+        'amount' => 25.00,
+        'status' => 'pending',
+        'created_at' => '2024-05-04T14:05:00+00:00',
+        'reviewed_by' => null,
+        'reviewed_at' => null,
+    ],
+];
+
+$withdrawalFinder = $db->prepare('SELECT id FROM withdrawal_requests WHERE user_id = :user_id AND amount = :amount AND status = :status AND created_at = :created_at');
+$withdrawalInsert = $db->prepare('INSERT INTO withdrawal_requests (user_id, amount, status, created_at, reviewed_by, reviewed_at) VALUES (:user_id, :amount, :status, :created_at, :reviewed_by, :reviewed_at)');
+
+foreach ($withdrawals as $request) {
+    $withdrawalFinder->execute([
+        'user_id' => $request['user_id'],
+        'amount' => $request['amount'],
+        'status' => $request['status'],
+        'created_at' => $request['created_at'],
+    ]);
+
+    if ($withdrawalFinder->fetch()) {
+        echo "Withdrawal request {$request['amount']} ({$request['status']}) already exists\n";
+        continue;
+    }
+
+    $withdrawalInsert->execute([
+        'user_id' => $request['user_id'],
+        'amount' => $request['amount'],
+        'status' => $request['status'],
+        'created_at' => $request['created_at'],
+        'reviewed_by' => $request['reviewed_by'],
+        'reviewed_at' => $request['reviewed_at'],
+    ]);
+    echo "Created withdrawal request {$request['amount']} ({$request['status']})\n";
+}
+
+$updateWallet = $db->prepare('UPDATE users SET wallet_balance = :balance WHERE id = :id');
+$updateWallet->execute([
+    'balance' => 25.00,
+    'id' => $playerId,
+]);
+
+echo "Updated wallet balance for player@example.com to 25.00\n";

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,108 @@
+# API Specification
+
+This document describes the current HTTP API for the Free Fire Tournament
+Platform backend included in this repository. All endpoints exchange JSON
+payloads and are prefixed with `/api`.
+
+## Authentication
+
+| Method | Endpoint        | Description                   |
+| ------ | --------------- | ----------------------------- |
+| POST   | `/api/register` | Register a new account        |
+| POST   | `/api/login`    | Obtain an access token        |
+| GET    | `/api/me`       | Retrieve authenticated profile|
+
+### Login Response
+
+```json
+{
+  "token": "<access_token>",
+  "expires_at": "2024-05-01T10:30:00+00:00",
+  "user": {
+    "id": 1,
+    "name": "Admin User",
+    "email": "admin@example.com",
+    "role": "admin"
+  }
+}
+```
+
+Include the token in the `Authorization: Bearer <token>` header to access
+protected routes.
+
+## Tournaments
+
+| Method | Endpoint                     | Role   | Description                                   |
+| ------ | ---------------------------- | ------ | --------------------------------------------- |
+| GET    | `/api/tournaments`           | Any    | List tournaments ordered by start time        |
+| GET    | `/api/tournaments/{id}`      | Any    | Retrieve tournament details, matches, players |
+| POST   | `/api/tournaments`           | Admin  | Create a tournament                            |
+| POST   | `/api/tournaments/{id}/join` | Auth   | Join a tournament (deducts entry fee)          |
+
+### Tournament Payload
+
+```json
+{
+  "name": "Solo Showdown",
+  "description": "128-player qualifier",
+  "entry_fee": 30,
+  "prize_pool": 1000,
+  "start_time": "2024-05-08T18:00:00+05:30"
+}
+```
+
+## Matches
+
+| Method | Endpoint                      | Role        | Description                                  |
+| ------ | ----------------------------- | ----------- | -------------------------------------------- |
+| POST   | `/api/matches`                | Admin       | Create a match and optionally assign staff   |
+| GET    | `/api/staff/matches`          | Staff       | List matches assigned to the staff member    |
+| POST   | `/api/matches/{id}/result`    | Staff/Admin | Update match status and submit results       |
+
+### Result Update Payload
+
+```json
+{
+  "status": "completed",
+  "result_text": "Squad 22 takes the Booyah!"
+}
+```
+
+## Wallet
+
+| Method | Endpoint                 | Role   | Description                                  |
+| ------ | ------------------------ | ------ | -------------------------------------------- |
+| GET    | `/api/wallet`            | Auth   | View balance and last 50 transactions        |
+| POST   | `/api/wallet/deposit`    | Auth   | Record a manual deposit                      |
+| POST   | `/api/wallet/withdraw`   | Auth   | Request a withdrawal (moves to pending)      |
+
+### Deposit Payload
+
+```json
+{
+  "amount": 200
+}
+```
+
+## Withdrawal Administration
+
+| Method | Endpoint                               | Role  | Description                              |
+| ------ | -------------------------------------- | ----- | ---------------------------------------- |
+| GET    | `/api/admin/withdrawals`               | Admin | List pending and processed withdrawals   |
+| POST   | `/api/admin/withdrawals/{id}/approve`  | Admin | Approve the withdrawal request           |
+| POST   | `/api/admin/withdrawals/{id}/reject`   | Admin | Reject the withdrawal and refund balance |
+
+## Error Format
+
+Errors are returned with an HTTP status code and body:
+
+```json
+{
+  "error": "Invalid credentials"
+}
+```
+
+## Rate Limiting & Pagination
+
+The starter implementation does not yet include rate limiting or pagination.
+These can be added using middleware and query parameters as the platform scales.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,74 @@
+# System Architecture
+
+The current implementation delivers a lightweight, self-contained backend for
+the Free Fire Tournament Platform. It is designed to run locally or on a single
+server while providing clear extension points for a production-ready deployment.
+
+## High-Level Components
+
+1. **PHP API Service**
+   - Built with vanilla PHP 8 and SQLite, avoiding heavy dependencies while the
+     product is still evolving.
+   - Exposes REST endpoints for authentication, tournaments, wallet management,
+     and role-specific workflows.
+   - Implements a tiny routing layer (`App\\Core\\App`) that maps HTTP methods
+     to closures for straightforward request handling.
+
+2. **SQLite Database**
+   - Stores users, tokens, tournaments, matches, registrations, wallet
+     transactions, and withdrawal requests.
+   - Managed via migration scripts (`bin/migrate.php`) so schema changes can be
+     version-controlled.
+
+3. **CLI Tooling**
+   - `bin/migrate.php` prepares the database.
+   - `bin/seed.php` provisions sample admin, staff, and player accounts for
+     quick testing.
+
+4. **Landing Page**
+   - `public/landing.php` serves a responsive marketing page with APK download
+     and support contact placeholders.
+
+## Request Lifecycle
+
+1. PHP's built-in server routes traffic to `public/index.php`.
+2. The bootstrap script loads the autoloader and instantiates service classes.
+3. Incoming requests are matched to handlers, which:
+   - Parse JSON payloads via `App\\Core\\Request`.
+   - Validate authentication using `App\\Auth\\AuthService` for protected
+     routes.
+   - Delegate to domain services (e.g., `TournamentService`, `WalletService`).
+4. Responses are serialized to JSON using `App\\Core\\Response` helpers.
+
+## Data Model Overview
+
+- **users** – Account details, hashed passwords, role, wallet balance.
+- **tokens** – Session tokens with expiration timestamps.
+- **tournaments** – Core tournament metadata and scheduling.
+- **matches** – Match records tied to tournaments with optional staff owners.
+- **registrations** – Player enrolments enforcing uniqueness per tournament.
+- **wallet_transactions** – Ledger of deposits, withdrawals, and entry fees.
+- **withdrawal_requests** – Admin-reviewed payout requests.
+
+## Security Considerations
+
+- Passwords stored using bcrypt via `password_hash`.
+- Bearer tokens stored in the database with expiry enforcement on each request.
+- Role-based guards restrict admin/staff/player functionality.
+
+## Extensibility Roadmap
+
+- Swap SQLite for MySQL/PostgreSQL by updating the PDO DSN in
+  `App\\Core\\Database`.
+- Replace the custom router with a micro-framework such as Slim or Laravel
+  Lumen for middleware and validation support.
+- Integrate payment gateways for automated deposits/withdrawals.
+- Add JWT support, rate limiting, and background job processing as load
+  increases.
+
+## Deployment Notes
+
+- Suitable for a single VPS or container using `php -S` behind Nginx/Apache.
+- Persistent storage must include the `storage/` directory for the SQLite file.
+- Use environment variables (e.g., `.env`) in future iterations to manage
+  secrets and configuration outside of source control.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,72 @@
+# Product Requirements
+
+This document highlights the core capabilities currently delivered by the backend
+implementation alongside the future features envisioned for the Free Fire
+Tournament Platform.
+
+## Personas
+
+- **Player** – Registers, manages wallet funds, and joins tournaments.
+- **Admin** – Configures tournaments, supervises finances, and reviews
+  withdrawals.
+- **Staff** – Oversees assigned matches and records final results.
+
+## Delivered Functionality
+
+| Area              | Capabilities                                                                 |
+| ----------------- | ----------------------------------------------------------------------------- |
+| Account           | Email registration, password login, bearer-token authentication.              |
+| Tournaments       | CRUD-lite support (create + list + detail) and participant enrolment.         |
+| Matches           | Admin match creation, staff assignment, and result submission.                |
+| Wallet            | Manual deposits, entry fee deductions, withdrawal requests, admin approvals.  |
+| Roles & Security  | Role-based guards for admin, staff, and player endpoints.                     |
+| Landing Website   | Static marketing page with APK download placeholder and support contact.      |
+
+## Roadmap Features
+
+### Player Experience
+
+1. **Profile Enhancements** – Avatar uploads, in-game identifiers, and device
+   verification.
+2. **Payment Integrations** – Payment gateway deposits, automatic payout
+   processing, and KYC validation.
+3. **Notifications** – Push notifications for match reminders, results, and
+   wallet changes.
+4. **Support Desk** – Ticketing workflows and chat-style conversations with
+   moderators.
+
+### Admin Console
+
+1. **Tournament Lifecycle** – Draft, publish, archive stages with cloning and
+   template support.
+2. **Staff Management** – Invitations, fine-grained permissions, and scheduling
+   tools.
+3. **Analytics** – Dashboards for player growth, revenue, and match health.
+4. **Content Management** – Editable website sections, news posts, and FAQs.
+
+### Staff Tools
+
+1. **Lobby Coordination** – Room credential distribution and presence tracking.
+2. **Evidence Handling** – Upload screenshots/videos for dispute management.
+3. **Escalations** – Structured incident reports routed to admins.
+
+### Public Website
+
+1. **Changelog & Versioning** – Automatically publish APK release notes.
+2. **SEO & Campaigns** – Landing page variations, newsletter signups, and UTM
+   tracking.
+3. **Community Content** – Blog posts, highlight reels, and winner spotlights.
+
+## Non-Functional Goals
+
+- **Performance** – Maintain sub-500 ms response times for the existing API on
+  modest infrastructure.
+- **Security** – Expand token management to JWT or OAuth2, enforce HTTPS, and
+  integrate audit logging for financial operations.
+- **Scalability** – Prepare migration path to MySQL/PostgreSQL and add caching
+  as concurrency grows.
+- **Observability** – Introduce structured logging and health-check endpoints to
+  monitor service uptime.
+
+These requirements will evolve as mobile and web clients are built on top of the
+new backend foundation.

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,0 +1,145 @@
+# Free Fire Tournament Platform User Manual
+
+## Introduction
+
+The Free Fire Tournament Platform is a PHP 8 web service that powers the player,
+admin, and staff experiences described in the project requirements. This manual
+explains how to prepare your environment, configure the backend, run migrations,
+and operate the HTTP API for local development or staging deployments.
+
+## Prerequisites
+
+- **PHP 8.1 or newer** with the SQLite3 extension enabled.
+- **Composer (optional)** if you plan to add third-party libraries.
+- A terminal environment capable of running PHP CLI scripts.
+
+All dependencies in the current codebase are part of PHP's standard library, so
+no package installation is required after PHP itself is installed.
+
+## Project Structure Overview
+
+```
+├── bin/                # CLI utilities for database setup and seeding
+├── docs/               # Documentation, including this manual
+├── public/             # HTTP entry point for the API and landing page
+├── src/                # Application source code (autoloaded PSR-4 style)
+└── storage/            # SQLite database files (created automatically)
+```
+
+## Initial Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone <repository-url>
+   cd tournament
+   ```
+
+2. **Verify PHP version**
+   ```bash
+   php -v
+   ```
+   Ensure the output shows PHP 8.1 or newer. Install or upgrade PHP if needed.
+
+3. **Create the storage directory (if missing)**
+   The `storage` directory is committed to the repository. If you perform a
+   clean checkout without it, create the directory manually:
+   ```bash
+   mkdir -p storage
+   ```
+
+## Database Migration and Seeding
+
+The platform uses an SQLite database located at `storage/database.sqlite`.
+
+> **Having trouble?** If `php bin/migrate.php` reports `could not find driver`,
+> enable the PDO SQLite extension. On Windows, uncomment `extension=pdo_sqlite`
+> and `extension=sqlite3` in your `php.ini`. On Debian/Ubuntu, run
+> `sudo apt install php-sqlite3` and restart PHP.
+
+1. **Run migrations** to create the schema:
+   ```bash
+   php bin/migrate.php
+   ```
+
+2. **Seed demo data** (optional but recommended for testing):
+   ```bash
+   php bin/seed.php
+   ```
+   This script provisions sample admin, staff, and player accounts and populates
+   example tournaments and matches. Refer to the script output for credentials.
+
+### Demo Data Overview
+
+| Role  | Email                | Password   | Notes |
+|-------|----------------------|------------|-------|
+| Admin | `admin@example.com`  | `admin123` | Can manage tournaments, wallets, and withdrawals. |
+| Staff | `staff@example.com`  | `staff123` | Assigned to update match results. |
+| User  | `player@example.com` | `player123`| Pre-enrolled in tournaments with wallet history. |
+
+Additional seeded records include:
+
+- **Tournaments**: “Free Fire Solo Showdown” (upcoming) and “Free Fire Champions Cup” (completed) with associated matches and registrations.
+- **Wallet Transactions**: Deposit, entry fee, approved withdrawal, and pending withdrawal request entries to exercise wallet summaries.
+- **Withdrawal Requests**: One approved and one pending request to demonstrate the admin review workflow.
+
+## Launching the HTTP Server
+
+Use PHP's built-in development server to expose the API and landing page:
+```bash
+php -S localhost:8000 -t public
+```
+The server will listen on port 8000 by default. Visit `http://localhost:8000`
+in a browser to view the landing page. API routes are available under `/api`.
+
+For production deployments, configure a proper web server (e.g., Nginx or
+Apache) to direct traffic to `public/index.php` and ensure PHP-FPM is running
+with appropriate security settings.
+
+## Authentication Workflow
+
+1. Register a new account via `POST /api/register` **or** log in with a seeded
+   account using `POST /api/login`.
+2. The login response returns a bearer token. Include it in subsequent requests:
+   ```
+   Authorization: Bearer <token>
+   ```
+3. Role-based routes (admin/staff) require accounts with the appropriate role as
+   defined in the database.
+
+## Core API Usage
+
+- **List tournaments**: `GET /api/tournaments`
+- **Join a tournament**: `POST /api/tournaments/{id}/join`
+- **Check wallet balance**: `GET /api/wallet`
+- **Request withdrawal**: `POST /api/wallet/withdraw`
+- **Admin approve withdrawal**: `POST /api/admin/withdrawals/{id}/approve`
+- **Staff record result**: `POST /api/matches/{id}/result`
+
+Refer to `docs/api.md` for the complete catalog with request/response payloads.
+
+## Managing Environment Variables
+
+Configuration values (e.g., database path) are defined in `src/Config.php`. For
+more complex setups, extend this file to load environment variables via `getenv`
+or a configuration library and update the service container accordingly.
+
+## Logs and Troubleshooting
+
+- The PHP built-in server logs requests and errors to stdout. Monitor the
+  console running `php -S` for real-time diagnostics.
+- Database issues usually stem from missing migrations. Re-run `php bin/migrate.php` if you encounter table-not-found errors.
+- To reset the environment, delete `storage/database.sqlite` and rerun the
+  migration and seed scripts.
+
+## Next Steps and Customization
+
+- Integrate a production-ready authentication mechanism (JWT, OAuth) as needed.
+- Replace SQLite with MySQL/PostgreSQL for larger deployments by updating
+  `src/Core/Database.php` and the configuration constants.
+- Connect the mobile and web front-ends to the documented API endpoints.
+- Add automated tests (PHPUnit/Pest) and CI workflows for quality assurance.
+
+---
+
+For additional architectural context, review `docs/architecture.md` and the API
+contract in `docs/api.md`.

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,137 @@
+<?php
+
+require_once __DIR__ . '/../src/autoload.php';
+
+use App\Auth\AuthService;
+use App\Core\App;
+use App\Core\Response;
+use App\Services\TournamentService;
+use App\Services\WalletService;
+
+$uri = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+if ($uri === '/' || $uri === '' || $uri === '/index.php') {
+    require __DIR__ . '/landing.php';
+    return;
+}
+
+$app = new App();
+$auth = new AuthService();
+$tournaments = new TournamentService();
+$wallet = new WalletService();
+
+$app->add('POST', '/api/register', function ($request) use ($auth) {
+    $auth->register($request->json());
+});
+
+$app->add('POST', '/api/login', function ($request) use ($auth) {
+    $auth->login($request->json());
+});
+
+$app->add('GET', '/api/me', function () use ($auth) {
+    $user = $auth->requireAuth();
+    if (!$user) {
+        return;
+    }
+    unset($user['password_hash']);
+    Response::json($user);
+});
+
+$app->add('GET', '/api/tournaments', function () use ($tournaments) {
+    $tournaments->list();
+});
+
+$app->add('GET', '/api/tournaments/{id}', function ($request, $params) use ($tournaments) {
+    $tournaments->get((int) $params['id']);
+});
+
+$app->add('POST', '/api/tournaments', function ($request) use ($auth, $tournaments) {
+    $user = $auth->requireAuth(['admin']);
+    if (!$user) {
+        return;
+    }
+    $tournaments->create($request->json(), $user);
+});
+
+$app->add('POST', '/api/tournaments/{id}/join', function ($request, $params) use ($auth, $tournaments) {
+    $user = $auth->requireAuth(['user', 'admin', 'staff']);
+    if (!$user) {
+        return;
+    }
+    $tournaments->join((int) $params['id'], $user);
+});
+
+$app->add('POST', '/api/matches', function ($request) use ($auth, $tournaments) {
+    $user = $auth->requireAuth(['admin']);
+    if (!$user) {
+        return;
+    }
+    $tournaments->createMatch($request->json(), $user);
+});
+
+$app->add('GET', '/api/staff/matches', function () use ($auth, $tournaments) {
+    $user = $auth->requireAuth(['staff']);
+    if (!$user) {
+        return;
+    }
+    $tournaments->listMatchesForStaff((int) $user['id']);
+});
+
+$app->add('POST', '/api/matches/{id}/result', function ($request, $params) use ($auth, $tournaments) {
+    $user = $auth->requireAuth(['staff', 'admin']);
+    if (!$user) {
+        return;
+    }
+    $tournaments->updateMatchResult((int) $params['id'], $request->json(), $user);
+});
+
+$app->add('GET', '/api/wallet', function () use ($auth, $wallet) {
+    $user = $auth->requireAuth(['user', 'admin', 'staff']);
+    if (!$user) {
+        return;
+    }
+    $wallet->summary((int) $user['id']);
+});
+
+$app->add('POST', '/api/wallet/deposit', function ($request) use ($auth, $wallet) {
+    $user = $auth->requireAuth(['user', 'admin', 'staff']);
+    if (!$user) {
+        return;
+    }
+    $payload = $request->json();
+    $wallet->deposit((int) $user['id'], (float) ($payload['amount'] ?? 0));
+});
+
+$app->add('POST', '/api/wallet/withdraw', function ($request) use ($auth, $wallet) {
+    $user = $auth->requireAuth(['user', 'admin', 'staff']);
+    if (!$user) {
+        return;
+    }
+    $payload = $request->json();
+    $wallet->requestWithdrawal((int) $user['id'], (float) ($payload['amount'] ?? 0));
+});
+
+$app->add('GET', '/api/admin/withdrawals', function () use ($auth, $wallet) {
+    $user = $auth->requireAuth(['admin']);
+    if (!$user) {
+        return;
+    }
+    Response::json($wallet->listWithdrawalRequests());
+});
+
+$app->add('POST', '/api/admin/withdrawals/{id}/approve', function ($request, $params) use ($auth, $wallet) {
+    $user = $auth->requireAuth(['admin']);
+    if (!$user) {
+        return;
+    }
+    $wallet->updateWithdrawalStatus((int) $params['id'], 'approved', (int) $user['id']);
+});
+
+$app->add('POST', '/api/admin/withdrawals/{id}/reject', function ($request, $params) use ($auth, $wallet) {
+    $user = $auth->requireAuth(['admin']);
+    if (!$user) {
+        return;
+    }
+    $wallet->updateWithdrawalStatus((int) $params['id'], 'rejected', (int) $user['id']);
+});
+
+$app->dispatch();

--- a/public/landing.php
+++ b/public/landing.php
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Free Fire Tournament Platform</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; background: #0e1320; color: #fff; }
+    header { padding: 3rem 1rem; text-align: center; background: linear-gradient(135deg, #ff512f, #dd2476); }
+    header h1 { margin: 0; font-size: 2.5rem; }
+    header p { font-size: 1.1rem; margin-top: 1rem; }
+    main { padding: 2rem 1rem; max-width: 960px; margin: 0 auto; }
+    .card-grid { display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    .card { background: rgba(255, 255, 255, 0.05); border-radius: 12px; padding: 1.5rem; box-shadow: 0 10px 30px rgba(0,0,0,0.2); }
+    .card h3 { margin-top: 0; color: #ff8a65; }
+    .download { text-align: center; margin-top: 2rem; }
+    .download a { display: inline-block; padding: 0.9rem 2.4rem; border-radius: 999px; background: #ff512f; color: #fff; font-weight: bold; text-decoration: none; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .download a:hover { transform: translateY(-2px); box-shadow: 0 12px 24px rgba(255,81,47,0.35); }
+    footer { text-align: center; padding: 1.5rem; background: #0b0f1a; font-size: 0.9rem; color: rgba(255,255,255,0.6); }
+    @media (prefers-color-scheme: light) {
+      body { background: #f5f6fb; color: #2c3144; }
+      header { color: #fff; }
+      .card { background: #fff; color: #2c3144; }
+      footer { background: #fff; color: #5b6180; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Free Fire Tournament Platform</h1>
+    <p>Compete, manage, and win with our all-in-one esports management suite.</p>
+  </header>
+  <main>
+    <section class="card-grid">
+      <article class="card">
+        <h3>Players</h3>
+        <p>Register, top up your wallet, join upcoming tournaments, and review match results in real time.</p>
+      </article>
+      <article class="card">
+        <h3>Admins</h3>
+        <p>Create events, monitor finances, manage staff, and control payouts through a secure dashboard.</p>
+      </article>
+      <article class="card">
+        <h3>Staff</h3>
+        <p>Moderate assigned lobbies, capture final standings, and flag issues directly from the field.</p>
+      </article>
+    </section>
+    <div class="download">
+      <a href="/downloads/app.apk">Download Android APK</a>
+    </div>
+    <section style="margin-top:3rem;">
+      <h2>Need help?</h2>
+      <p>Email <a href="mailto:support@tournament.local" style="color:#ff8a65;">support@tournament.local</a> for onboarding and partnership requests.</p>
+    </section>
+  </main>
+  <footer>
+    &copy; <?php echo date('Y'); ?> Free Fire Tournament Platform. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/src/Auth/AuthService.php
+++ b/src/Auth/AuthService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Auth;
+
+use App\Config;
+use App\Core\Database;
+use App\Core\Response;
+use DateInterval;
+use DateTimeImmutable;
+use PDO;
+
+class AuthService
+{
+    private PDO $db;
+
+    public function __construct()
+    {
+        $this->db = Database::getConnection();
+    }
+
+    public function register(array $data): void
+    {
+        $name = trim($data['name'] ?? '');
+        $email = strtolower(trim($data['email'] ?? ''));
+        $password = $data['password'] ?? '';
+        $role = $data['role'] ?? 'user';
+
+        if ($name === '' || $email === '' || $password === '') {
+            Response::json(['error' => 'Name, email, and password are required'], 422);
+            return;
+        }
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            Response::json(['error' => 'Invalid email address'], 422);
+            return;
+        }
+
+        $allowedRoles = ['user', 'admin', 'staff'];
+        if (!in_array($role, $allowedRoles, true)) {
+            $role = 'user';
+        }
+
+        $stmt = $this->db->prepare('SELECT id FROM users WHERE email = :email');
+        $stmt->execute(['email' => $email]);
+        if ($stmt->fetch()) {
+            Response::json(['error' => 'Email already registered'], 409);
+            return;
+        }
+
+        $passwordHash = password_hash($password, PASSWORD_BCRYPT);
+        $stmt = $this->db->prepare('INSERT INTO users (name, email, password_hash, role, wallet_balance, created_at) VALUES (:name, :email, :password_hash, :role, 0, :created_at)');
+        $stmt->execute([
+            'name' => $name,
+            'email' => $email,
+            'password_hash' => $passwordHash,
+            'role' => $role,
+            'created_at' => (new DateTimeImmutable())->format(DATE_ATOM),
+        ]);
+
+        Response::json(['message' => 'Registration successful']);
+    }
+
+    public function login(array $data): void
+    {
+        $email = strtolower(trim($data['email'] ?? ''));
+        $password = $data['password'] ?? '';
+
+        if ($email === '' || $password === '') {
+            Response::json(['error' => 'Email and password are required'], 422);
+            return;
+        }
+
+        $stmt = $this->db->prepare('SELECT * FROM users WHERE email = :email');
+        $stmt->execute(['email' => $email]);
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$user || !password_verify($password, $user['password_hash'])) {
+            Response::json(['error' => 'Invalid credentials'], 401);
+            return;
+        }
+
+        $token = bin2hex(random_bytes(32));
+        $expires = (new DateTimeImmutable())->add(new DateInterval('PT' . Config::TOKEN_TTL_MINUTES . 'M'));
+
+        $stmt = $this->db->prepare('INSERT INTO tokens (user_id, token, expires_at) VALUES (:user_id, :token, :expires_at)');
+        $stmt->execute([
+            'user_id' => $user['id'],
+            'token' => $token,
+            'expires_at' => $expires->format(DATE_ATOM),
+        ]);
+
+        Response::json([
+            'token' => $token,
+            'expires_at' => $expires->format(DATE_ATOM),
+            'user' => [
+                'id' => (int) $user['id'],
+                'name' => $user['name'],
+                'email' => $user['email'],
+                'role' => $user['role'],
+            ],
+        ]);
+    }
+
+    public function requireAuth(array $roles = []): ?array
+    {
+        $headers = getallheaders();
+        $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? null;
+        if (!$authHeader || !preg_match('/Bearer\s+(\S+)/', $authHeader, $matches)) {
+            Response::json(['error' => 'Authorization header missing'], 401);
+            return null;
+        }
+
+        $token = $matches[1];
+        $stmt = $this->db->prepare('SELECT t.token, t.expires_at, u.* FROM tokens t JOIN users u ON u.id = t.user_id WHERE t.token = :token');
+        $stmt->execute(['token' => $token]);
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$result) {
+            Response::json(['error' => 'Invalid token'], 401);
+            return null;
+        }
+
+        if (new DateTimeImmutable($result['expires_at']) < new DateTimeImmutable()) {
+            Response::json(['error' => 'Token expired'], 401);
+            return null;
+        }
+
+        if ($roles && !in_array($result['role'], $roles, true)) {
+            Response::json(['error' => 'Forbidden'], 403);
+            return null;
+        }
+
+        return $result;
+    }
+}

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App;
+
+class Config
+{
+    public const DB_PATH = __DIR__ . '/../storage/database.sqlite';
+    public const TOKEN_TTL_MINUTES = 60 * 24; // 24 hours
+}

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Core;
+
+class App
+{
+    private array $routes = [];
+
+    public function add(string $method, string $pattern, callable $handler): void
+    {
+        $this->routes[] = [$method, $pattern, $handler];
+    }
+
+    public function dispatch(): void
+    {
+        $request = new Request();
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        $uri = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+
+        foreach ($this->routes as [$routeMethod, $pattern, $handler]) {
+            if (strtoupper($method) !== strtoupper($routeMethod)) {
+                continue;
+            }
+
+            $regex = $this->convertPatternToRegex($pattern);
+            if (preg_match($regex, $uri, $matches)) {
+                $params = [];
+                foreach ($matches as $key => $value) {
+                    if (!is_int($key)) {
+                        $params[$key] = $value;
+                    }
+                }
+                $handler($request, $params);
+                return;
+            }
+        }
+
+        Response::json(['error' => 'Not found'], 404);
+    }
+
+    private function convertPatternToRegex(string $pattern): string
+    {
+        $regex = preg_replace('#\{([a-zA-Z_][a-zA-Z0-9_]*)\}#', '(?P<$1>[^/]+)', $pattern);
+        return '#^' . $regex . '$#';
+    }
+}

--- a/src/Core/Database.php
+++ b/src/Core/Database.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Core;
+
+use App\Config;
+use PDO;
+use PDOException;
+use RuntimeException;
+
+class Database
+{
+    private static ?PDO $connection = null;
+
+    public static function getConnection(): PDO
+    {
+        if (self::$connection === null) {
+            $dsn = 'sqlite:' . Config::DB_PATH;
+            try {
+                if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+                    $message = 'The PDO SQLite driver is not available. Enable the pdo_sqlite extension in your php.ini or install the php-sqlite3 package.';
+                    self::handleConnectionFailure('SQLite driver missing', $message);
+                }
+
+                self::$connection = new PDO($dsn);
+                self::$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+                self::$connection->exec('PRAGMA foreign_keys = ON');
+            } catch (PDOException $e) {
+                self::handleConnectionFailure('Database connection failed', $e->getMessage());
+            }
+        }
+
+        return self::$connection;
+    }
+
+    private static function handleConnectionFailure(string $message, string $details): void
+    {
+        if (PHP_SAPI === 'cli') {
+            throw new RuntimeException($message . ': ' . $details);
+        }
+
+        http_response_code(500);
+        header('Content-Type: application/json');
+        echo json_encode(['error' => $message, 'details' => $details]);
+        exit;
+    }
+}

--- a/src/Core/Request.php
+++ b/src/Core/Request.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Core;
+
+class Request
+{
+    private array $body;
+
+    public function __construct()
+    {
+        $input = file_get_contents('php://input');
+        $this->body = $input ? (json_decode($input, true) ?? []) : [];
+    }
+
+    public function json(): array
+    {
+        return $this->body;
+    }
+
+    public function getHeader(string $name): ?string
+    {
+        $key = 'HTTP_' . strtoupper(str_replace('-', '_', $name));
+        return $_SERVER[$key] ?? null;
+    }
+
+    public function query(string $key, $default = null)
+    {
+        return $_GET[$key] ?? $default;
+    }
+}

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Core;
+
+class Response
+{
+    public static function json($data, int $status = 200): void
+    {
+        http_response_code($status);
+        header('Content-Type: application/json');
+        echo json_encode($data, JSON_PRETTY_PRINT);
+    }
+}

--- a/src/Services/TournamentService.php
+++ b/src/Services/TournamentService.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Services;
+
+use App\Core\Database;
+use App\Core\Response;
+use DateTimeImmutable;
+use PDO;
+
+class TournamentService
+{
+    private PDO $db;
+
+    public function __construct()
+    {
+        $this->db = Database::getConnection();
+    }
+
+    public function list(): void
+    {
+        $stmt = $this->db->query('SELECT * FROM tournaments ORDER BY start_time ASC');
+        $tournaments = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        Response::json($tournaments);
+    }
+
+    public function create(array $data, array $user): void
+    {
+        $name = trim($data['name'] ?? '');
+        $description = trim($data['description'] ?? '');
+        $entryFee = (float) ($data['entry_fee'] ?? 0);
+        $prizePool = (float) ($data['prize_pool'] ?? 0);
+        $startTime = $data['start_time'] ?? null;
+
+        if ($name === '' || !$startTime) {
+            Response::json(['error' => 'Name and start_time are required'], 422);
+            return;
+        }
+
+        $stmt = $this->db->prepare('INSERT INTO tournaments (name, description, entry_fee, prize_pool, start_time, status, created_by, created_at) VALUES (:name, :description, :entry_fee, :prize_pool, :start_time, :status, :created_by, :created_at)');
+        $stmt->execute([
+            'name' => $name,
+            'description' => $description,
+            'entry_fee' => $entryFee,
+            'prize_pool' => $prizePool,
+            'start_time' => $startTime,
+            'status' => $data['status'] ?? 'upcoming',
+            'created_by' => $user['id'],
+            'created_at' => (new DateTimeImmutable())->format(DATE_ATOM),
+        ]);
+
+        Response::json(['message' => 'Tournament created'], 201);
+    }
+
+    public function get(int $id): void
+    {
+        $stmt = $this->db->prepare('SELECT * FROM tournaments WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $tournament = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$tournament) {
+            Response::json(['error' => 'Tournament not found'], 404);
+            return;
+        }
+
+        $matchesStmt = $this->db->prepare('SELECT m.*, u.name AS staff_name FROM matches m LEFT JOIN users u ON u.id = m.assigned_staff_id WHERE m.tournament_id = :id');
+        $matchesStmt->execute(['id' => $id]);
+        $tournament['matches'] = $matchesStmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $participantsStmt = $this->db->prepare('SELECT u.id, u.name FROM registrations r JOIN users u ON u.id = r.user_id WHERE r.tournament_id = :id');
+        $participantsStmt->execute(['id' => $id]);
+        $tournament['participants'] = $participantsStmt->fetchAll(PDO::FETCH_ASSOC);
+
+        Response::json($tournament);
+    }
+
+    public function join(int $id, array $user): void
+    {
+        $this->db->beginTransaction();
+        try {
+            $stmt = $this->db->prepare('SELECT * FROM tournaments WHERE id = :id');
+            $stmt->execute(['id' => $id]);
+            $tournament = $stmt->fetch(PDO::FETCH_ASSOC);
+            if (!$tournament) {
+                $this->db->rollBack();
+                Response::json(['error' => 'Tournament not found'], 404);
+                return;
+            }
+
+            if ($tournament['status'] !== 'upcoming') {
+                $this->db->rollBack();
+                Response::json(['error' => 'Tournament closed'], 409);
+                return;
+            }
+
+            $checkStmt = $this->db->prepare('SELECT id FROM registrations WHERE user_id = :user_id AND tournament_id = :tournament_id');
+            $checkStmt->execute([
+                'user_id' => $user['id'],
+                'tournament_id' => $id,
+            ]);
+            if ($checkStmt->fetch()) {
+                $this->db->rollBack();
+                Response::json(['error' => 'Already registered'], 409);
+                return;
+            }
+
+            $entryFee = (float) $tournament['entry_fee'];
+            if ($entryFee > 0) {
+                $balanceStmt = $this->db->prepare('SELECT wallet_balance FROM users WHERE id = :id');
+                $balanceStmt->execute(['id' => $user['id']]);
+                $balance = (float) $balanceStmt->fetchColumn();
+                if ($balance < $entryFee) {
+                    $this->db->rollBack();
+                    Response::json(['error' => 'Insufficient balance'], 422);
+                    return;
+                }
+
+                $updateWallet = $this->db->prepare('UPDATE users SET wallet_balance = wallet_balance - :amount WHERE id = :id');
+                $updateWallet->execute([
+                    'amount' => $entryFee,
+                    'id' => $user['id'],
+                ]);
+
+                $transactionStmt = $this->db->prepare('INSERT INTO wallet_transactions (user_id, type, amount, status, created_at, metadata) VALUES (:user_id, :type, :amount, :status, :created_at, :metadata)');
+                $transactionStmt->execute([
+                    'user_id' => $user['id'],
+                    'type' => 'entry_fee',
+                    'amount' => $entryFee,
+                    'status' => 'completed',
+                    'created_at' => (new DateTimeImmutable())->format(DATE_ATOM),
+                    'metadata' => json_encode(['tournament_id' => $id]),
+                ]);
+            }
+
+            $registrationStmt = $this->db->prepare('INSERT INTO registrations (user_id, tournament_id, status, created_at) VALUES (:user_id, :tournament_id, :status, :created_at)');
+            $registrationStmt->execute([
+                'user_id' => $user['id'],
+                'tournament_id' => $id,
+                'status' => 'confirmed',
+                'created_at' => (new DateTimeImmutable())->format(DATE_ATOM),
+            ]);
+
+            $this->db->commit();
+            Response::json(['message' => 'Successfully joined tournament']);
+        } catch (\Throwable $e) {
+            $this->db->rollBack();
+            Response::json(['error' => 'Failed to join tournament', 'details' => $e->getMessage()], 500);
+        }
+    }
+
+    public function createMatch(array $data, array $user): void
+    {
+        $tournamentId = (int) ($data['tournament_id'] ?? 0);
+        $name = trim($data['name'] ?? '');
+        $staffId = $data['staff_id'] ?? null;
+
+        if ($tournamentId <= 0 || $name === '') {
+            Response::json(['error' => 'tournament_id and name are required'], 422);
+            return;
+        }
+
+        $stmt = $this->db->prepare('INSERT INTO matches (tournament_id, name, status, assigned_staff_id, created_at) VALUES (:tournament_id, :name, :status, :staff, :created_at)');
+        $stmt->execute([
+            'tournament_id' => $tournamentId,
+            'name' => $name,
+            'status' => $data['status'] ?? 'scheduled',
+            'staff' => $staffId,
+            'created_at' => (new DateTimeImmutable())->format(DATE_ATOM),
+        ]);
+
+        Response::json(['message' => 'Match created'], 201);
+    }
+
+    public function listMatchesForStaff(int $staffId): void
+    {
+        $stmt = $this->db->prepare('SELECT m.*, t.name AS tournament_name FROM matches m JOIN tournaments t ON t.id = m.tournament_id WHERE m.assigned_staff_id = :staff_id');
+        $stmt->execute(['staff_id' => $staffId]);
+        Response::json($stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+
+    public function updateMatchResult(int $matchId, array $payload, array $staff): void
+    {
+        $stmt = $this->db->prepare('SELECT * FROM matches WHERE id = :id');
+        $stmt->execute(['id' => $matchId]);
+        $match = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$match) {
+            Response::json(['error' => 'Match not found'], 404);
+            return;
+        }
+
+        if ($match['assigned_staff_id'] && (int) $match['assigned_staff_id'] !== (int) $staff['id']) {
+            Response::json(['error' => 'Not assigned to this match'], 403);
+            return;
+        }
+
+        $update = $this->db->prepare('UPDATE matches SET status = :status, result_text = :result WHERE id = :id');
+        $update->execute([
+            'status' => $payload['status'] ?? 'completed',
+            'result' => $payload['result_text'] ?? null,
+            'id' => $matchId,
+        ]);
+
+        Response::json(['message' => 'Match updated']);
+    }
+}

--- a/src/Services/WalletService.php
+++ b/src/Services/WalletService.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Services;
+
+use App\Core\Database;
+use App\Core\Response;
+use DateTimeImmutable;
+use PDO;
+
+class WalletService
+{
+    private PDO $db;
+
+    public function __construct()
+    {
+        $this->db = Database::getConnection();
+    }
+
+    public function summary(int $userId): void
+    {
+        $stmt = $this->db->prepare('SELECT wallet_balance FROM users WHERE id = :id');
+        $stmt->execute(['id' => $userId]);
+        $balance = (float) $stmt->fetchColumn();
+
+        $transactionsStmt = $this->db->prepare('SELECT * FROM wallet_transactions WHERE user_id = :id ORDER BY created_at DESC LIMIT 50');
+        $transactionsStmt->execute(['id' => $userId]);
+
+        Response::json([
+            'balance' => $balance,
+            'transactions' => $transactionsStmt->fetchAll(PDO::FETCH_ASSOC),
+        ]);
+    }
+
+    public function deposit(int $userId, float $amount): void
+    {
+        if ($amount <= 0) {
+            Response::json(['error' => 'Amount must be positive'], 422);
+            return;
+        }
+
+        $this->db->beginTransaction();
+        try {
+            $update = $this->db->prepare('UPDATE users SET wallet_balance = wallet_balance + :amount WHERE id = :id');
+            $update->execute([
+                'amount' => $amount,
+                'id' => $userId,
+            ]);
+
+            $transaction = $this->db->prepare('INSERT INTO wallet_transactions (user_id, type, amount, status, created_at, metadata) VALUES (:user_id, :type, :amount, :status, :created_at, :metadata)');
+            $transaction->execute([
+                'user_id' => $userId,
+                'type' => 'deposit',
+                'amount' => $amount,
+                'status' => 'completed',
+                'created_at' => (new DateTimeImmutable())->format(DATE_ATOM),
+                'metadata' => json_encode(['source' => 'manual_top_up']),
+            ]);
+
+            $this->db->commit();
+            Response::json(['message' => 'Deposit recorded']);
+        } catch (\Throwable $e) {
+            $this->db->rollBack();
+            Response::json(['error' => 'Failed to deposit', 'details' => $e->getMessage()], 500);
+        }
+    }
+
+    public function requestWithdrawal(int $userId, float $amount): void
+    {
+        if ($amount <= 0) {
+            Response::json(['error' => 'Amount must be positive'], 422);
+            return;
+        }
+
+        $this->db->beginTransaction();
+        try {
+            $balanceStmt = $this->db->prepare('SELECT wallet_balance FROM users WHERE id = :id');
+            $balanceStmt->execute(['id' => $userId]);
+            $balance = (float) $balanceStmt->fetchColumn();
+            if ($balance < $amount) {
+                $this->db->rollBack();
+                Response::json(['error' => 'Insufficient balance'], 422);
+                return;
+            }
+
+            $update = $this->db->prepare('UPDATE users SET wallet_balance = wallet_balance - :amount WHERE id = :id');
+            $update->execute([
+                'amount' => $amount,
+                'id' => $userId,
+            ]);
+
+            $transaction = $this->db->prepare('INSERT INTO wallet_transactions (user_id, type, amount, status, created_at, metadata) VALUES (:user_id, :type, :amount, :status, :created_at, :metadata)');
+            $transaction->execute([
+                'user_id' => $userId,
+                'type' => 'withdrawal',
+                'amount' => $amount,
+                'status' => 'pending',
+                'created_at' => (new DateTimeImmutable())->format(DATE_ATOM),
+                'metadata' => json_encode([]),
+            ]);
+
+            $withdrawal = $this->db->prepare('INSERT INTO withdrawal_requests (user_id, amount, status, created_at) VALUES (:user_id, :amount, :status, :created_at)');
+            $withdrawal->execute([
+                'user_id' => $userId,
+                'amount' => $amount,
+                'status' => 'pending',
+                'created_at' => (new DateTimeImmutable())->format(DATE_ATOM),
+            ]);
+
+            $this->db->commit();
+            Response::json(['message' => 'Withdrawal requested']);
+        } catch (\Throwable $e) {
+            $this->db->rollBack();
+            Response::json(['error' => 'Failed to request withdrawal', 'details' => $e->getMessage()], 500);
+        }
+    }
+
+    public function listWithdrawalRequests(): array
+    {
+        $stmt = $this->db->query('SELECT wr.*, u.name AS user_name FROM withdrawal_requests wr JOIN users u ON u.id = wr.user_id ORDER BY wr.created_at DESC');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function updateWithdrawalStatus(int $id, string $status, int $adminId): void
+    {
+        $allowed = ['approved', 'rejected'];
+        if (!in_array($status, $allowed, true)) {
+            Response::json(['error' => 'Invalid status'], 422);
+            return;
+        }
+
+        $this->db->beginTransaction();
+        try {
+            $stmt = $this->db->prepare('SELECT * FROM withdrawal_requests WHERE id = :id');
+            $stmt->execute(['id' => $id]);
+            $request = $stmt->fetch(PDO::FETCH_ASSOC);
+            if (!$request) {
+                $this->db->rollBack();
+                Response::json(['error' => 'Request not found'], 404);
+                return;
+            }
+
+            if ($request['status'] !== 'pending') {
+                $this->db->rollBack();
+                Response::json(['error' => 'Request already processed'], 409);
+                return;
+            }
+
+            $updateRequest = $this->db->prepare('UPDATE withdrawal_requests SET status = :status, reviewed_by = :admin_id, reviewed_at = :reviewed_at WHERE id = :id');
+            $updateRequest->execute([
+                'status' => $status,
+                'admin_id' => $adminId,
+                'reviewed_at' => (new DateTimeImmutable())->format(DATE_ATOM),
+                'id' => $id,
+            ]);
+
+            $transactionStatus = $status === 'approved' ? 'completed' : 'cancelled';
+            $updateTransaction = $this->db->prepare('UPDATE wallet_transactions SET status = :status WHERE user_id = :user_id AND type = :type AND status = :current_status AND amount = :amount');
+            $updateTransaction->execute([
+                'status' => $transactionStatus,
+                'user_id' => $request['user_id'],
+                'type' => 'withdrawal',
+                'current_status' => 'pending',
+                'amount' => $request['amount'],
+            ]);
+
+            if ($status === 'rejected') {
+                $refund = $this->db->prepare('UPDATE users SET wallet_balance = wallet_balance + :amount WHERE id = :id');
+                $refund->execute([
+                    'amount' => $request['amount'],
+                    'id' => $request['user_id'],
+                ]);
+            }
+
+            $this->db->commit();
+            Response::json(['message' => 'Withdrawal ' . $status]);
+        } catch (\Throwable $e) {
+            $this->db->rollBack();
+            Response::json(['error' => 'Failed to update request', 'details' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/src/Support/Migration.php
+++ b/src/Support/Migration.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Support;
+
+use App\Core\Database;
+use PDO;
+
+class Migration
+{
+    public static function run(): void
+    {
+        $db = Database::getConnection();
+        self::createUsersTable($db);
+        self::createTokensTable($db);
+        self::createTournamentsTable($db);
+        self::createMatchesTable($db);
+        self::createRegistrationsTable($db);
+        self::createWalletTransactionsTable($db);
+        self::createWithdrawalsTable($db);
+    }
+
+    private static function createUsersTable(PDO $db): void
+    {
+        $db->exec('CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL UNIQUE,
+            password_hash TEXT NOT NULL,
+            role TEXT NOT NULL,
+            wallet_balance REAL NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL
+        )');
+    }
+
+    private static function createTokensTable(PDO $db): void
+    {
+        $db->exec('CREATE TABLE IF NOT EXISTS tokens (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            token TEXT NOT NULL UNIQUE,
+            expires_at TEXT NOT NULL,
+            FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+        )');
+    }
+
+    private static function createTournamentsTable(PDO $db): void
+    {
+        $db->exec('CREATE TABLE IF NOT EXISTS tournaments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            description TEXT,
+            entry_fee REAL NOT NULL DEFAULT 0,
+            prize_pool REAL NOT NULL DEFAULT 0,
+            start_time TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_by INTEGER,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(created_by) REFERENCES users(id)
+        )');
+    }
+
+    private static function createMatchesTable(PDO $db): void
+    {
+        $db->exec('CREATE TABLE IF NOT EXISTS matches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tournament_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            status TEXT NOT NULL,
+            result_text TEXT,
+            assigned_staff_id INTEGER,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(tournament_id) REFERENCES tournaments(id) ON DELETE CASCADE,
+            FOREIGN KEY(assigned_staff_id) REFERENCES users(id)
+        )');
+    }
+
+    private static function createRegistrationsTable(PDO $db): void
+    {
+        $db->exec('CREATE TABLE IF NOT EXISTS registrations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            tournament_id INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE(user_id, tournament_id),
+            FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY(tournament_id) REFERENCES tournaments(id) ON DELETE CASCADE
+        )');
+    }
+
+    private static function createWalletTransactionsTable(PDO $db): void
+    {
+        $db->exec('CREATE TABLE IF NOT EXISTS wallet_transactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            type TEXT NOT NULL,
+            amount REAL NOT NULL,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            metadata TEXT,
+            FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+        )');
+    }
+
+    private static function createWithdrawalsTable(PDO $db): void
+    {
+        $db->exec('CREATE TABLE IF NOT EXISTS withdrawal_requests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            amount REAL NOT NULL,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            reviewed_by INTEGER,
+            reviewed_at TEXT,
+            FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY(reviewed_by) REFERENCES users(id)
+        )');
+    }
+}

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,0 +1,12 @@
+<?php
+spl_autoload_register(function (string $class): void {
+    $prefix = 'App\\';
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return;
+    }
+    $relative = substr($class, strlen($prefix));
+    $path = __DIR__ . '/' . str_replace('\\', '/', $relative) . '.php';
+    if (file_exists($path)) {
+        require_once $path;
+    }
+});


### PR DESCRIPTION
## Summary
- extend the CLI seed script to populate demo tournaments, matches, registrations, wallet transactions, and withdrawal requests while keeping reruns idempotent
- initialize demo wallet balances via scripted transactions and ensure prerequisite user IDs exist before seeding related tables
- document the seeded accounts and supporting records in the user manual for quick reference

## Testing
- php bin/migrate.php
- php bin/seed.php
- php -l bin/seed.php

------
https://chatgpt.com/codex/tasks/task_e_68d623f65e708329b0a7c127d14ed931